### PR TITLE
Fix misleading error message when multiple steps have clean output dir disabled

### DIFF
--- a/nuget-agent/src/jetbrains/buildServer/nuget/agent/runner/pack/PackRunnerOutputDirectoryTrackerImpl.java
+++ b/nuget-agent/src/jetbrains/buildServer/nuget/agent/runner/pack/PackRunnerOutputDirectoryTrackerImpl.java
@@ -65,8 +65,7 @@ public class PackRunnerOutputDirectoryTrackerImpl implements PackRunnerOutputDir
         return CleanOutcome.CLEANED_BEFORE;
       }
 
-      //if (Boolean.FALSE.equals(aBoolean))
-      return CleanOutcome.NOT_CLEANED_BEFORE;
+      return cleanEnabled ? CleanOutcome.NOT_CLEANED_BEFORE : CleanOutcome.NO_CLEAN_REQUIRED;
     }
   }
 }


### PR DESCRIPTION
Fixes #14.

I've only written the one test for this, and that pretty much a copy of the one above it. I'm not a java developer, so please forgive any lack of knowledge around style or java conventions etc.