### PR TITLE
Use Project-Specific URLs in TeamCity NuGet Feed

### DIFF
--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/NuGetFeedAuthParametersProvider.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/NuGetFeedAuthParametersProvider.kt
@@ -1,6 +1,6 @@
 package jetbrains.buildServer.nuget.feed.server
 
-import jetbrains.buildServer.RootUrlHolder
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
 import jetbrains.buildServer.agent.AgentRuntimeProperties
 import jetbrains.buildServer.agent.Constants
 import jetbrains.buildServer.nuget.common.NuGetServerConstants
@@ -23,7 +23,7 @@ import javax.ws.rs.core.UriBuilder
 class NuGetFeedAuthParametersProvider(private val mySettings: NuGetServerSettings,
                                       private val myProjectManager: ProjectManager,
                                       private val myRepositoryManager: RepositoryManager,
-                                      private val myRootUrlHolder: RootUrlHolder)
+                                      private val myRootUrlResolver: ProjectAwareRootUrlResolver)
     : BuildStartContextProcessor {
 
     override fun updateParameters(context: BuildStartContext) {
@@ -59,7 +59,7 @@ class NuGetFeedAuthParametersProvider(private val mySettings: NuGetServerSetting
                 )
                 context.addSharedParameter(
                         feedReferencePrefix + feedSuffix + NuGetServerConstants.FEED_REF_PUBLIC_URL_SUFFIX,
-                        UriBuilder.fromUri(myRootUrlHolder.rootUrl).replacePath(httpAuthFeedPath).build().toString()
+                        UriBuilder.fromUri(myRootUrlResolver.getRootUrlByProjectExternalId(project.externalId)).replacePath(httpAuthFeedPath).build().toString()
                 )
             }
         }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/tab/PackagesController.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/tab/PackagesController.kt
@@ -2,7 +2,7 @@
 
 package jetbrains.buildServer.nuget.feed.server.tab
 
-import jetbrains.buildServer.RootUrlHolder
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
 import jetbrains.buildServer.controllers.AuthorizationInterceptor
 import jetbrains.buildServer.controllers.BaseController
 import jetbrains.buildServer.nuget.feed.server.PermissionChecker
@@ -26,7 +26,7 @@ class PackagesController(auth: AuthorizationInterceptor,
                          web: WebControllerManager,
                          private val myDescriptor: PluginDescriptor,
                          private val myLoginConfiguration: LoginConfiguration,
-                         private val myRootUrlHolder: RootUrlHolder,
+                         private val myRootUrlResolver: ProjectAwareRootUrlResolver,
                          private val myRepositoryRegistry: RepositoryRegistry,
                          private val myRepositoriesManager: RepositoryManager,
                          private val myProjectManager: ProjectManager) : BaseController() {
@@ -51,7 +51,7 @@ class PackagesController(auth: AuthorizationInterceptor,
             val usages = myRepositoryRegistry.findUsagesProvider(it.type.type)
                     ?.getUsagesCount(it)
                     ?: 0
-            ProjectRepository(it, project, myRootUrlHolder.rootUrl, usages)
+            ProjectRepository(it, project, myRootUrlResolver.getRootUrlByProjectExternalId(project.externalId), usages)
         }
         mv.model["project"] = project
         mv.model["repositories"] = repositories

--- a/nuget-server/src/jetbrains/buildServer/nuget/server/trigger/TriggerUrlRootPostProcessor.java
+++ b/nuget-server/src/jetbrains/buildServer/nuget/server/trigger/TriggerUrlRootPostProcessor.java
@@ -2,7 +2,7 @@
 
 package jetbrains.buildServer.nuget.server.trigger;
 
-import jetbrains.buildServer.RootUrlHolder;
+import jetbrains.buildServer.ProjectAwareRootUrlResolver;
 import jetbrains.buildServer.nuget.server.TriggerUrlPostProcessor;
 import jetbrains.buildServer.parameters.ReferencesResolverUtil;
 import jetbrains.buildServer.serverSide.SBuildType;
@@ -18,16 +18,17 @@ import static jetbrains.buildServer.agent.AgentRuntimeProperties.TEAMCITY_SERVER
  * @author Eugene Petrenko (eugene.petrenko@jetbrains.com)
  */
 public class TriggerUrlRootPostProcessor implements TriggerUrlPostProcessor, PositionAware {
-  private final RootUrlHolder myHolder;
+  private final ProjectAwareRootUrlResolver myRootUrlResolver;
 
-  public TriggerUrlRootPostProcessor(@NotNull RootUrlHolder holder) {
-    myHolder = holder;
+  public TriggerUrlRootPostProcessor(@NotNull ProjectAwareRootUrlResolver rootUrlResolver) {
+    myRootUrlResolver = rootUrlResolver;
   }
 
   @NotNull
   public String updateTriggerUrl(@NotNull SBuildType buildType, @NotNull String source) {
     if (!ReferencesResolverUtil.mayContainReference(source)) return source;
-    return source.replace(ReferencesResolverUtil.makeReference(TEAMCITY_SERVER_URL), myHolder.getRootUrl());
+    return source.replace(ReferencesResolverUtil.makeReference(TEAMCITY_SERVER_URL),
+                          myRootUrlResolver.getRootUrlByBuildTypeExternalId(buildType.getExternalId()));
   }
 
   @NotNull

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedAuthParametersProviderTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedAuthParametersProviderTest.kt
@@ -1,6 +1,6 @@
 package jetbrains.buildServer.nuget.tests.feed
 
-import jetbrains.buildServer.RootUrlHolder
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedAuthParametersProvider
 import jetbrains.buildServer.nuget.feed.server.NuGetServerSettings
 import jetbrains.buildServer.nuget.feed.server.packages.NuGetRepository
@@ -27,7 +27,7 @@ class NuGetFeedAuthParametersProviderTest {
         val serverSettings = m.mock(NuGetServerSettings::class.java)
         val projectManager = m.mock(ProjectManager::class.java)
         val repositoryManager = m.mock(RepositoryManager::class.java)
-        val rootUrlHolder = m.mock(RootUrlHolder::class.java)
+        val rootUrlResolver = m.mock(ProjectAwareRootUrlResolver::class.java)
         val buildStartContext = m.mock(BuildStartContext::class.java)
         val build = m.mock(SRunningBuild::class.java)
         val project = m.mock(SProject::class.java)
@@ -36,7 +36,7 @@ class NuGetFeedAuthParametersProviderTest {
         val projectId = "projectId"
 
         val parametersProvider = NuGetFeedAuthParametersProvider(
-                serverSettings, projectManager, repositoryManager, rootUrlHolder
+                serverSettings, projectManager, repositoryManager, rootUrlResolver
         )
 
         m.checking(object: Expectations() {
@@ -71,7 +71,7 @@ class NuGetFeedAuthParametersProviderTest {
                     }
                 })
 
-                oneOf(rootUrlHolder).rootUrl
+                oneOf(rootUrlResolver).getRootUrlByProjectExternalId(projectId)
                 will(returnValue("http://localhost"))
 
                 oneOf(buildStartContext).addSharedParameter("teamcity.nuget.feed.agentSideIndexing", "true")

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/NamedPackagesUpdateCheckerTest.java
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/NamedPackagesUpdateCheckerTest.java
@@ -4,7 +4,7 @@ package jetbrains.buildServer.nuget.tests.server;
 
 import jetbrains.buildServer.BaseTestCase;
 import jetbrains.buildServer.ExtensionHolder;
-import jetbrains.buildServer.RootUrlHolder;
+import jetbrains.buildServer.ProjectAwareRootUrlResolver;
 import jetbrains.buildServer.agent.AgentRuntimeProperties;
 import jetbrains.buildServer.buildTriggers.BuildTriggerDescriptor;
 import jetbrains.buildServer.buildTriggers.BuildTriggerException;
@@ -68,7 +68,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
   private PackageChangesManager chk;
   private Map<String, String> params;
   private File nugetFakePath;
-  private RootUrlHolder myRootUrlHolder;
+  private ProjectAwareRootUrlResolver myRootUrlResolver;
   private BuildTypeEx myBuildType;
   private ProjectEx myProject;
 
@@ -87,7 +87,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
     params = new TreeMap<String, String>();
     final ServerToolManager toolManager = m.mock(ServerToolManager.class);
     chk = m.mock(PackageChangesManager.class);
-    myRootUrlHolder = m.mock(RootUrlHolder.class);
+    myRootUrlResolver = m.mock(ProjectAwareRootUrlResolver.class);
     myBuildType = m.mock(BuildTypeEx.class);
     myProject = m.mock(ProjectEx.class);
 
@@ -108,8 +108,9 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
       allowing(context).getBuildType(); will(returnValue(myBuildType));
       allowing(desr).getProperties(); will(returnValue(params));
       allowing(toolManager).getUnpackedToolVersionPath(with(any(ToolType.class)), with(any(String.class)), with(any(SProject.class))); will(returnValue(nugetHome));
-      allowing(extensionHolder).getExtensions(TriggerUrlPostProcessor.class); will(returnValue(Collections.<TriggerUrlPostProcessor>singletonList(new TriggerUrlRootPostProcessor(myRootUrlHolder))));
+      allowing(extensionHolder).getExtensions(TriggerUrlPostProcessor.class); will(returnValue(Collections.<TriggerUrlPostProcessor>singletonList(new TriggerUrlRootPostProcessor(myRootUrlResolver))));
       allowing(myBuildType).getProject(); will(returnValue(myProject));
+      allowing(myBuildType).getExternalId(); will(returnValue("bt1"));
 
       allowing(si).canStartNuGetProcesses(); will(new CustomAction("Return myIsWindows") {
         public Object invoke(Invocation invocation) throws Throwable {
@@ -129,7 +130,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
     params.put(TriggerConstants.SOURCE, "%"+ AgentRuntimeProperties.TEAMCITY_SERVER_URL+"%/a/b/c");
 
     m.checking(new Expectations(){{
-      allowing(myRootUrlHolder).getRootUrl(); will(returnValue("http://some-teamcity-with-nuget.org/jonnyzzz"));
+      allowing(myRootUrlResolver).getRootUrlByBuildTypeExternalId("bt1"); will(returnValue("http://some-teamcity-with-nuget.org/jonnyzzz"));
 
       oneOf(chk).checkPackage(with(req(nugetFakePath, "http://some-teamcity-with-nuget.org/jonnyzzz/a/b/c", "NUnit", null)));
       will(returnValue(CheckResult.fromResult(Arrays.asList(new SourcePackageInfo("src", "pkg", "5.6.87")))));


### PR DESCRIPTION
TeamCity NuGet Feed always uses the global URL. 

However, it may be necessary to use project-specific URLs for package publishing. This pull request adds support for that.