### PR TITLE
[TW-101700] Propagate the use of project-scoped URLs in the NuGet feed

### DIFF
--- a/nuget-feed/resources/META-INF/build-server-plugin-nuget-server.xml
+++ b/nuget-feed/resources/META-INF/build-server-plugin-nuget-server.xml
@@ -23,6 +23,7 @@
   <bean class="jetbrains.buildServer.nuget.feed.server.controllers.requests.NuGetFeedRequestsController"/>
 
   <bean class="jetbrains.buildServer.nuget.feed.server.impl.NuGetServerSettingsImpl"/>
+  <bean class="jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver"/>
 
   <bean class="jetbrains.buildServer.nuget.feed.server.index.impl.security.NuGetFeedPermissionCheckerImpl"/>
   <bean class="jetbrains.buildServer.nuget.feed.server.index.impl.NuGetBuildFeedsProviderImpl"/>

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/NuGetFeedAuthParametersProvider.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/NuGetFeedAuthParametersProvider.kt
@@ -1,6 +1,6 @@
 package jetbrains.buildServer.nuget.feed.server
 
-import jetbrains.buildServer.RootUrlHolder
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
 import jetbrains.buildServer.agent.AgentRuntimeProperties
 import jetbrains.buildServer.agent.Constants
 import jetbrains.buildServer.nuget.common.NuGetServerConstants
@@ -23,7 +23,7 @@ import javax.ws.rs.core.UriBuilder
 class NuGetFeedAuthParametersProvider(private val mySettings: NuGetServerSettings,
                                       private val myProjectManager: ProjectManager,
                                       private val myRepositoryManager: RepositoryManager,
-                                      private val myRootUrlHolder: RootUrlHolder)
+                                      private val myRootUrlResolver: ProjectAwareRootUrlResolver)
     : BuildStartContextProcessor {
 
     override fun updateParameters(context: BuildStartContext) {
@@ -47,6 +47,10 @@ class NuGetFeedAuthParametersProvider(private val mySettings: NuGetServerSetting
                 .getRepositories(it, true)
                 .filterIsInstance<NuGetRepository>()
 
+            // repositories may be inherited from ancestor projects, but the URL an agent must use
+            // is the one configured for the project the build belongs to
+            val rootUrl = myRootUrlResolver.getRootUrlByProjectInternalId(build.projectId)
+
             repositories.forEach { repository ->
                 val project = myProjectManager.findProjectById(repository.projectId) ?: return@forEach
                 val feedPath = NuGetUtils.getProjectFeedPath(project.externalId, repository.name)
@@ -59,7 +63,7 @@ class NuGetFeedAuthParametersProvider(private val mySettings: NuGetServerSetting
                 )
                 context.addSharedParameter(
                         feedReferencePrefix + feedSuffix + NuGetServerConstants.FEED_REF_PUBLIC_URL_SUFFIX,
-                        UriBuilder.fromUri(myRootUrlHolder.rootUrl).replacePath(httpAuthFeedPath).build().toString()
+                        UriBuilder.fromUri(rootUrl).replacePath(httpAuthFeedPath).build().toString()
                 )
             }
         }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/impl/HttpServletRequestUtil.java
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/impl/HttpServletRequestUtil.java
@@ -16,14 +16,16 @@ public class HttpServletRequestUtil {
   }
 
   public static String getRootUrlWithAuthenticationType(HttpServletRequest request) {
-    final String rootUrl = getRootUrl(request);
+    return getRootUrl(request) + getAuthenticationTypePath(request);
+  }
+
+  public static String getAuthenticationTypePath(HttpServletRequest request) {
     final String pathWithoutContext = WebUtil.getPathWithoutContext(request);
     final String pathWithoutAuthenticationType = WebUtil.getPathWithoutAuthenticationType(request);
     final int index = pathWithoutContext.indexOf(pathWithoutAuthenticationType);
     if (index > 0) {
-      final String authenticationType = pathWithoutContext.substring(0, index);
-      return rootUrl + authenticationType;
+      return pathWithoutContext.substring(0, index);
     }
-    return rootUrl;
+    return "";
   }
 }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/impl/NuGetFeedRootUrlResolver.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/impl/NuGetFeedRootUrlResolver.kt
@@ -1,0 +1,21 @@
+package jetbrains.buildServer.nuget.feed.server.impl
+
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
+import javax.servlet.http.HttpServletRequest
+
+class NuGetFeedRootUrlResolver(private val myRootUrlResolver: ProjectAwareRootUrlResolver) {
+
+    /**
+     * NuGet clients may reach the server via a host which differs from the configured root URL,
+     * so the URL derived from the request is kept unless the project redefines the root URL.
+     */
+    fun getRootUrl(request: HttpServletRequest, projectExternalId: String?): String {
+        val projectRootUrl = myRootUrlResolver.getRootUrlByProjectExternalId(projectExternalId)
+        val rootUrl = if (projectRootUrl == myRootUrlResolver.rootUrl) HttpServletRequestUtil.getRootUrl(request) else projectRootUrl
+        // a project may define the root URL with a trailing slash, while callers append absolute paths
+        return rootUrl.removeSuffix("/")
+    }
+
+    fun getRootUrlWithAuthenticationType(request: HttpServletRequest, projectExternalId: String?): String =
+        getRootUrl(request, projectExternalId) + HttpServletRequestUtil.getAuthenticationTypePath(request)
+}

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/NuGetFeedData.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/NuGetFeedData.kt
@@ -3,9 +3,11 @@ package jetbrains.buildServer.nuget.feed.server.index
 import jetbrains.buildServer.nuget.common.index.PackageConstants
 import java.util.*
 
+/**
+ * [projectExtId] is used to build feed and package URLs, so it must be the real project external id
+ * whenever the instance may reach URL generation. Feed identity is [projectId] + [feedId] only.
+ */
 class NuGetFeedData(val projectId: String, val projectExtId: String, val feedId: String) {
-
-    constructor(projectId: String, feedId: String) : this(projectId, projectId, feedId)
 
     val key: String by lazy {
         return@lazy if (projectId == DEFAULT_PROJECT_ID && feedId == DEFAULT_FEED_ID) {
@@ -36,9 +38,10 @@ class NuGetFeedData(val projectId: String, val projectExtId: String, val feedId:
     }
 
     companion object {
+        // the root project uses the same value as its internal and external id
         private const val DEFAULT_PROJECT_ID = "_Root"
         const val DEFAULT_FEED_ID = "default"
         @JvmField
-        val DEFAULT = NuGetFeedData(DEFAULT_PROJECT_ID, DEFAULT_FEED_ID)
+        val DEFAULT = NuGetFeedData(DEFAULT_PROJECT_ID, DEFAULT_PROJECT_ID, DEFAULT_FEED_ID)
     }
 }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/impl/NuGetBuildFeedsProviderImpl.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/impl/NuGetBuildFeedsProviderImpl.kt
@@ -40,7 +40,7 @@ class NuGetBuildFeedsProviderImpl(
 
         // Feeds with implicit indexing come from the build project's own hierarchy, so they are always writable.
         NuGetIndexUtils.findFeedsWithIndexing(buildProject, myRepositoryManager).forEach {
-            accessible.add(NuGetFeedData(it.projectId, it.name))
+            accessible.add(NuGetFeedData(it.projectId, it.projectId, it.name))
         }
 
         try {
@@ -49,7 +49,7 @@ class NuGetBuildFeedsProviderImpl(
                     NuGetUtils.feedIdToData(feedId)?.let { (feedProjectExtId, feedName) ->
                         val feedProject = myProjectManager.findProjectByExternalId(feedProjectExtId)
                         val feed = feedProject?.let {
-                            NuGetFeedData(it.projectId, feedName)
+                            NuGetFeedData(it.projectId, it.externalId, feedName)
                         }
                         if (feed != null && isFeedAccessible(feedProject, feed)) {
                             accessible.add(feed)

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/impl/security/NuGetFeedPermissionCheckerImpl.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/index/impl/security/NuGetFeedPermissionCheckerImpl.kt
@@ -19,5 +19,6 @@ class NuGetFeedPermissionCheckerImpl(private val myProjectManager: ProjectManage
     override fun getWritableFeeds(buildProject: SProject): Set<NuGetFeedData> =
         myRepositoryManager.getRepositories(buildProject, true)
             .filterIsInstance<NuGetRepository>()
-            .mapTo(hashSetOf()) { NuGetFeedData(it.projectId, it.name) }
+            // feed identity is (projectId, feedId); the external id is irrelevant for the comparison below
+            .mapTo(hashSetOf()) { NuGetFeedData(it.projectId, it.projectId, it.name) }
 }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonExtensions.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonExtensions.kt
@@ -7,7 +7,6 @@ import jetbrains.buildServer.nuget.common.index.ODataDataFormat
 import jetbrains.buildServer.nuget.common.version.SemanticVersion
 import jetbrains.buildServer.nuget.feed.server.MetadataConstants
 import jetbrains.buildServer.nuget.feed.server.NuGetUtils
-import jetbrains.buildServer.nuget.feed.server.impl.HttpServletRequestUtil
 import jetbrains.buildServer.nuget.feed.server.index.NuGetIndexEntry
 import jetbrains.buildServer.nuget.feedReader.NuGetPackageAttributes
 import jetbrains.buildServer.web.util.WebUtil
@@ -102,14 +101,6 @@ internal fun HttpServletRequest.includeSemVer2(): Boolean {
             it >= VERSION_20
         }
     } ?: false
-}
-
-internal fun HttpServletRequest.getRootUrl(): String {
-    return HttpServletRequestUtil.getRootUrl(this);
-}
-
-internal fun HttpServletRequest.getRootUrlWithAuthenticationType(): String {
-    return HttpServletRequestUtil.getRootUrlWithAuthenticationType(this);
 }
 
 private val VERSION_20 = SemanticVersion.valueOf("2.0.0")!!

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonNuGetFeedContext.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonNuGetFeedContext.kt
@@ -1,19 +1,24 @@
 package jetbrains.buildServer.nuget.feed.server.json
 
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeed
+import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
 import jetbrains.buildServer.nuget.feed.server.index.NuGetIndexEntry
 import jetbrains.buildServer.nuget.feedReader.NuGetPackageAttributes
 import javax.servlet.http.HttpServletRequest
 
-class JsonNuGetFeedContext(val feed: NuGetFeed, request: HttpServletRequest) {
+class JsonNuGetFeedContext(val feed: NuGetFeed,
+                           feedData: NuGetFeedData,
+                           request: HttpServletRequest,
+                           rootUrlResolver: NuGetFeedRootUrlResolver) {
     val rootUrl: String
     val rootWithAuthenticationTypeUrl: String
     val servletPath: String
     val pathInfo: String
 
     init {
-        rootUrl = request.getRootUrl()
-        rootWithAuthenticationTypeUrl = request.getRootUrlWithAuthenticationType()
+        rootUrl = rootUrlResolver.getRootUrl(request, feedData.projectExtId)
+        rootWithAuthenticationTypeUrl = rootUrlResolver.getRootUrlWithAuthenticationType(request, feedData.projectExtId)
         servletPath = request.servletPath
         pathInfo = request.pathInfo
     }

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonPackageContentHandler.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonPackageContentHandler.kt
@@ -2,6 +2,7 @@ package jetbrains.buildServer.nuget.feed.server.json
 
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedConstants
 import jetbrains.buildServer.nuget.feed.server.controllers.NuGetFeedHandler
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedFactory
 import jetbrains.buildServer.serverSide.TeamCityProperties
@@ -11,7 +12,8 @@ import javax.servlet.http.HttpServletResponse
 class JsonPackageContentHandler(
         private val feedFactory: NuGetFeedFactory,
         private val packageSourceFactory: JsonPackageSourceFactory,
-        private val adapterFactory: JsonPackageAdapterFactory) : NuGetFeedHandler {
+        private val adapterFactory: JsonPackageAdapterFactory,
+        private val rootUrlResolver: NuGetFeedRootUrlResolver) : NuGetFeedHandler {
     override fun handleRequest(feedData: NuGetFeedData, request: HttpServletRequest, response: HttpServletResponse) {
         val matchResult = FLAT_CONTAINER_URL.find(request.pathInfo)
         if (matchResult == null) {
@@ -21,7 +23,7 @@ class JsonPackageContentHandler(
 
         val (id, version, _, file, extension) = matchResult.destructured
         val feed = feedFactory.createFeed(feedData)
-        val context = JsonNuGetFeedContext(feed, request)
+        val context = JsonNuGetFeedContext(feed, feedData, request, rootUrlResolver)
 
         if (version == "index.json" && file.isEmpty()) {
             if (DispatcherUtils.isAsyncEnabled()) {

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonRegistrationHandler.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonRegistrationHandler.kt
@@ -2,6 +2,7 @@ package jetbrains.buildServer.nuget.feed.server.json
 
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedConstants
 import jetbrains.buildServer.nuget.feed.server.controllers.NuGetFeedHandler
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedFactory
 import jetbrains.buildServer.serverSide.TeamCityProperties
@@ -10,13 +11,14 @@ import javax.servlet.http.HttpServletResponse
 
 class JsonRegistrationHandler(private val feedFactory: NuGetFeedFactory,
                               private val packageSourceFactory: JsonPackageSourceFactory,
-                              private val adapterFactory: JsonPackageAdapterFactory) : NuGetFeedHandler {
+                              private val adapterFactory: JsonPackageAdapterFactory,
+                              private val rootUrlResolver: NuGetFeedRootUrlResolver) : NuGetFeedHandler {
     override fun handleRequest(feedData: NuGetFeedData, request: HttpServletRequest, response: HttpServletResponse) {
         val matchResult = REGISTRATION_URL.find(request.pathInfo)
         if (matchResult != null) {
             val (id, resource) = matchResult.destructured
             val feed = feedFactory.createFeed(feedData)
-            val context = JsonNuGetFeedContext(feed, request)
+            val context = JsonNuGetFeedContext(feed, feedData, request, rootUrlResolver)
 
             if (resource == "index") {
                 if (DispatcherUtils.isAsyncEnabled()) {

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonSearchQueryHandler.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonSearchQueryHandler.kt
@@ -2,6 +2,7 @@ package jetbrains.buildServer.nuget.feed.server.json
 
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedConstants
 import jetbrains.buildServer.nuget.feed.server.controllers.NuGetFeedHandler
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedFactory
 import jetbrains.buildServer.serverSide.TeamCityProperties
@@ -11,10 +12,11 @@ import javax.servlet.http.HttpServletResponse
 class JsonSearchQueryHandler(
         private val feedFactory: NuGetFeedFactory,
         private val packageSourceFactory: JsonPackageSourceFactory,
-        private val adapterFactory: JsonPackageAdapterFactory) : NuGetFeedHandler {
+        private val adapterFactory: JsonPackageAdapterFactory,
+        private val rootUrlResolver: NuGetFeedRootUrlResolver) : NuGetFeedHandler {
     override fun handleRequest(feedData: NuGetFeedData, request: HttpServletRequest, response: HttpServletResponse) {
         val feed = feedFactory.createFeed(feedData)
-        val context = JsonNuGetFeedContext(feed, request)
+        val context = JsonNuGetFeedContext(feed, feedData, request, rootUrlResolver)
 
         if (DispatcherUtils.isAsyncEnabled()) {
             DispatcherUtils.dispatchSearchPackages(request, response, context)

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonServiceIndexHandler.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/json/JsonServiceIndexHandler.kt
@@ -1,11 +1,12 @@
 package jetbrains.buildServer.nuget.feed.server.json
 
 import jetbrains.buildServer.nuget.feed.server.controllers.NuGetFeedHandler
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class JsonServiceIndexHandler : NuGetFeedHandler {
+class JsonServiceIndexHandler(private val rootUrlResolver: NuGetFeedRootUrlResolver) : NuGetFeedHandler {
     override fun handleRequest(feedData: NuGetFeedData, request: HttpServletRequest, response: HttpServletResponse) {
         if (request.pathInfo != "/index.json") {
             response.sendError(HttpServletResponse.SC_NOT_FOUND, "Requested resource not found")
@@ -14,7 +15,7 @@ class JsonServiceIndexHandler : NuGetFeedHandler {
 
         val feedPathV3 = request.servletPath
         val feedPathV2 = feedPathV3.replaceAfterLast("/", "v2")
-        val rootUrl = request.getRootUrl()
+        val rootUrl = rootUrlResolver.getRootUrl(request, feedData.projectExtId)
 
         val responseText = JsonServiceIndexHandler::class.java.getResourceAsStream("/feed-metadata/NuGet-V3.json").use {
             it.bufferedReader().readText()

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/OlingoRequestHandler.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/OlingoRequestHandler.kt
@@ -11,6 +11,7 @@ import jetbrains.buildServer.nuget.feed.server.cache.ResponseCache
 import jetbrains.buildServer.nuget.feed.server.controllers.NuGetFeedHandler
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeed
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedData
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.index.NuGetFeedFactory
 import jetbrains.buildServer.nuget.feed.server.olingo.data.OlingoDataSource
 import jetbrains.buildServer.nuget.feed.server.olingo.processor.NuGetServiceFactory
@@ -26,7 +27,8 @@ import javax.servlet.http.HttpServletResponse
  * Request handler based on Olingo library.
  */
 open class OlingoRequestHandler(private val myFeedFactory: NuGetFeedFactory,
-                                private val myCache: ResponseCache) : NuGetFeedHandler {
+                                private val myCache: ResponseCache,
+                                private val myRootUrlResolver: NuGetFeedRootUrlResolver) : NuGetFeedHandler {
     private val myServletsCache: Cache<String, Pair<ODataServlet, NuGetFeed>>
 
     init {
@@ -63,7 +65,7 @@ open class OlingoRequestHandler(private val myFeedFactory: NuGetFeedFactory,
         } ?: throw Exception("Failed to create servlet")
 
         val apiVersion = request.getAttribute(NuGetFeedConstants.NUGET_FEED_API_VERSION) as NuGetAPIVersion
-        val serviceFactory = NuGetServiceFactory(OlingoDataSource(feed, apiVersion))
+        val serviceFactory = NuGetServiceFactory(OlingoDataSource(feed, apiVersion), myRootUrlResolver, feedData.projectExtId)
         request.setAttribute(ODataServiceFactory.FACTORY_INSTANCE_LABEL, serviceFactory)
 
         try {

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/processor/NuGetPackagesProcessor.java
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/processor/NuGetPackagesProcessor.java
@@ -6,7 +6,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.UriBuilder;
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedConstants;
-import jetbrains.buildServer.nuget.feed.server.impl.HttpServletRequestUtil;
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver;
 import jetbrains.buildServer.nuget.feed.server.index.NuGetIndexEntry;
 import jetbrains.buildServer.nuget.feed.server.json.JsonExtensions;
 import jetbrains.buildServer.nuget.feed.server.olingo.data.OlingoDataSource;
@@ -29,6 +29,7 @@ import org.apache.olingo.odata2.api.uri.UriParser;
 import org.apache.olingo.odata2.api.uri.expression.*;
 import org.apache.olingo.odata2.api.uri.info.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -46,15 +47,24 @@ public class NuGetPackagesProcessor extends ODataSingleProcessor {
   private final BeanPropertyAccess myValueAccess;
   private final OlingoDataSource myDataSource;
   private final ExpressionEvaluator myEvaluator;
+  private final NuGetFeedRootUrlResolver myRootUrlResolver;
+  private final String myProjectExternalId;
 
-  public NuGetPackagesProcessor(@NotNull final OlingoDataSource dataSource) {
-    this(dataSource, new BeanPropertyAccess());
+  public NuGetPackagesProcessor(@NotNull final OlingoDataSource dataSource,
+                                @NotNull final NuGetFeedRootUrlResolver rootUrlResolver,
+                                @Nullable final String projectExternalId) {
+    this(dataSource, new BeanPropertyAccess(), rootUrlResolver, projectExternalId);
   }
 
-  public NuGetPackagesProcessor(final OlingoDataSource dataSource, final BeanPropertyAccess valueAccess) {
+  public NuGetPackagesProcessor(final OlingoDataSource dataSource,
+                                final BeanPropertyAccess valueAccess,
+                                @NotNull final NuGetFeedRootUrlResolver rootUrlResolver,
+                                @Nullable final String projectExternalId) {
     myDataSource = dataSource;
     myValueAccess = valueAccess;
     myEvaluator = new ExpressionEvaluator(valueAccess);
+    myRootUrlResolver = rootUrlResolver;
+    myProjectExternalId = projectExternalId;
   }
 
   @Override
@@ -142,7 +152,7 @@ public class NuGetPackagesProcessor extends ODataSingleProcessor {
       context = context.getBatchParentContext();
     }
     final HttpServletRequest request = (HttpServletRequest) context.getParameter(ODataContext.HTTP_SERVLET_REQUEST_OBJECT);
-    return URI.create(HttpServletRequestUtil.getRootUrlWithAuthenticationType(request));
+    return URI.create(myRootUrlResolver.getRootUrlWithAuthenticationType(request, myProjectExternalId));
   }
 
   private String getSkipToken(GetEntitySetUriInfo uriInfo) {

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/processor/NuGetServiceFactory.java
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/olingo/processor/NuGetServiceFactory.java
@@ -6,6 +6,7 @@ import jetbrains.buildServer.nuget.common.index.PackageConstants;
 import jetbrains.buildServer.nuget.feed.server.MetadataConstants;
 import jetbrains.buildServer.nuget.feed.server.NuGetAPIVersion;
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedConstants;
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver;
 import jetbrains.buildServer.nuget.feed.server.olingo.data.OlingoDataSource;
 import jetbrains.buildServer.nuget.feedReader.NuGetPackageAttributes;
 import jetbrains.buildServer.util.Action;
@@ -16,6 +17,8 @@ import org.apache.olingo.odata2.api.edm.provider.*;
 import org.apache.olingo.odata2.api.exception.ODataException;
 import org.apache.olingo.odata2.api.processor.ODataContext;
 import org.apache.olingo.odata2.core.edm.provider.EdmxProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.InputStream;
@@ -31,8 +34,15 @@ public class NuGetServiceFactory extends ODataServiceFactory {
   private static final Map<String, Action<Property>> PROPERTY_CONFIGS;
   private static final Map<NuGetAPIVersion, EdmxProvider> EDMX_PROVIDERS;
 
-  public NuGetServiceFactory(OlingoDataSource dataSource) {
+  private final NuGetFeedRootUrlResolver myRootUrlResolver;
+  private final String myProjectExternalId;
+
+  public NuGetServiceFactory(OlingoDataSource dataSource,
+                             @NotNull NuGetFeedRootUrlResolver rootUrlResolver,
+                             @Nullable String projectExternalId) {
     myDataSource = dataSource;
+    myRootUrlResolver = rootUrlResolver;
+    myProjectExternalId = projectExternalId;
   }
 
   @Override
@@ -40,7 +50,7 @@ public class NuGetServiceFactory extends ODataServiceFactory {
     final HttpServletRequest request = (HttpServletRequest) context.getParameter(ODataContext.HTTP_SERVLET_REQUEST_OBJECT);
     final NuGetAPIVersion apiVersion = (NuGetAPIVersion) request.getAttribute(NuGetFeedConstants.NUGET_FEED_API_VERSION);
     final EdmxProvider edmxProvider = EDMX_PROVIDERS.get(apiVersion);
-    return createODataSingleProcessorService(edmxProvider, new NuGetPackagesProcessor(myDataSource));
+    return createODataSingleProcessorService(edmxProvider, new NuGetPackagesProcessor(myDataSource, myRootUrlResolver, myProjectExternalId));
   }
 
   private static EdmxProvider getEdmProvider(final NuGetAPIVersion version) throws ODataException {

--- a/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/tab/PackagesController.kt
+++ b/nuget-feed/src/jetbrains/buildServer/nuget/feed/server/tab/PackagesController.kt
@@ -2,10 +2,10 @@
 
 package jetbrains.buildServer.nuget.feed.server.tab
 
-import jetbrains.buildServer.RootUrlHolder
 import jetbrains.buildServer.controllers.AuthorizationInterceptor
 import jetbrains.buildServer.controllers.BaseController
 import jetbrains.buildServer.nuget.feed.server.PermissionChecker
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
 import jetbrains.buildServer.serverSide.ProjectManager
 import jetbrains.buildServer.serverSide.auth.LoginConfiguration
 import jetbrains.buildServer.serverSide.packages.RepositoryRegistry
@@ -26,7 +26,7 @@ class PackagesController(auth: AuthorizationInterceptor,
                          web: WebControllerManager,
                          private val myDescriptor: PluginDescriptor,
                          private val myLoginConfiguration: LoginConfiguration,
-                         private val myRootUrlHolder: RootUrlHolder,
+                         private val myRootUrlResolver: NuGetFeedRootUrlResolver,
                          private val myRepositoryRegistry: RepositoryRegistry,
                          private val myRepositoriesManager: RepositoryManager,
                          private val myProjectManager: ProjectManager) : BaseController() {
@@ -47,11 +47,12 @@ class PackagesController(auth: AuthorizationInterceptor,
         val user = SessionUser.getUser(request)
         myPermChecker.checkViewPermissions(user, project)
 
+        val rootUrl = myRootUrlResolver.getRootUrl(request, project.externalId)
         val repositories = myRepositoriesManager.getRepositories(project, false).map {
             val usages = myRepositoryRegistry.findUsagesProvider(it.type.type)
                     ?.getUsagesCount(it)
                     ?: 0
-            ProjectRepository(it, project, myRootUrlHolder.rootUrl, usages)
+            ProjectRepository(it, project, rootUrl, usages)
         }
         mv.model["project"] = project
         mv.model["repositories"] = repositories

--- a/nuget-feed/src/jetbrains/buildServer/serverSide/packages/impl/RepositoryManagerImpl.java
+++ b/nuget-feed/src/jetbrains/buildServer/serverSide/packages/impl/RepositoryManagerImpl.java
@@ -70,7 +70,7 @@ public class RepositoryManagerImpl implements RepositoryManager, CachingTypedIdG
         project.removeFeature(feature.getId());
         project.persist(myConfigActionFactory.createAction(project, "NuGet feed with name \"" + name + "\" was removed"));
 
-        NuGetFeedData feedData = new NuGetFeedData(project.getProjectId(), name);
+        NuGetFeedData feedData = new NuGetFeedData(project.getProjectId(), project.getExternalId(), name);
         Iterator<BuildMetadataEntry> entries = myMetadataStorage.getAllEntries(feedData.getKey());
         while (entries.hasNext()) {
             BuildMetadataEntry entry = entries.next();
@@ -115,7 +115,7 @@ public class RepositoryManagerImpl implements RepositoryManager, CachingTypedIdG
 
             updateFeedReferences(project, new Pair<>(project.getExternalId(), oldName), new Pair<>(project.getExternalId(), repository.getName()));
 
-            NuGetFeedData feedData = new NuGetFeedData(project.getProjectId(), oldName);
+            NuGetFeedData feedData = new NuGetFeedData(project.getProjectId(), project.getExternalId(), oldName);
             Iterator<BuildMetadataEntry> entries = myMetadataStorage.getAllEntries(feedData.getKey());
             while (entries.hasNext()) {
                 BuildMetadataEntry entry = entries.next();

--- a/nuget-server/src/jetbrains/buildServer/nuget/server/trigger/TriggerUrlRootPostProcessor.java
+++ b/nuget-server/src/jetbrains/buildServer/nuget/server/trigger/TriggerUrlRootPostProcessor.java
@@ -2,10 +2,11 @@
 
 package jetbrains.buildServer.nuget.server.trigger;
 
-import jetbrains.buildServer.RootUrlHolder;
+import jetbrains.buildServer.ProjectAwareRootUrlResolver;
 import jetbrains.buildServer.nuget.server.TriggerUrlPostProcessor;
 import jetbrains.buildServer.parameters.ReferencesResolverUtil;
 import jetbrains.buildServer.serverSide.SBuildType;
+import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.util.positioning.PositionAware;
 import jetbrains.buildServer.util.positioning.PositionConstraint;
 import org.jetbrains.annotations.NotNull;
@@ -18,16 +19,18 @@ import static jetbrains.buildServer.agent.AgentRuntimeProperties.TEAMCITY_SERVER
  * @author Eugene Petrenko (eugene.petrenko@jetbrains.com)
  */
 public class TriggerUrlRootPostProcessor implements TriggerUrlPostProcessor, PositionAware {
-  private final RootUrlHolder myHolder;
+  private final ProjectAwareRootUrlResolver myRootUrlResolver;
 
-  public TriggerUrlRootPostProcessor(@NotNull RootUrlHolder holder) {
-    myHolder = holder;
+  public TriggerUrlRootPostProcessor(@NotNull ProjectAwareRootUrlResolver rootUrlResolver) {
+    myRootUrlResolver = rootUrlResolver;
   }
 
   @NotNull
   public String updateTriggerUrl(@NotNull SBuildType buildType, @NotNull String source) {
     if (!ReferencesResolverUtil.mayContainReference(source)) return source;
-    return source.replace(ReferencesResolverUtil.makeReference(TEAMCITY_SERVER_URL), myHolder.getRootUrl());
+    // a project may define the root URL with a trailing slash, while the trigger URL continues with an absolute path
+    final String rootUrl = StringUtil.removeTailingSlash(myRootUrlResolver.getRootUrlByProjectExternalId(buildType.getProject().getExternalId()));
+    return source.replace(ReferencesResolverUtil.makeReference(TEAMCITY_SERVER_URL), rootUrl);
   }
 
   @NotNull

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedAuthParametersProviderTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedAuthParametersProviderTest.kt
@@ -1,6 +1,6 @@
 package jetbrains.buildServer.nuget.tests.feed
 
-import jetbrains.buildServer.RootUrlHolder
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
 import jetbrains.buildServer.nuget.feed.server.NuGetFeedAuthParametersProvider
 import jetbrains.buildServer.nuget.feed.server.NuGetServerSettings
 import jetbrains.buildServer.nuget.feed.server.packages.NuGetRepository
@@ -27,7 +27,7 @@ class NuGetFeedAuthParametersProviderTest {
         val serverSettings = m.mock(NuGetServerSettings::class.java)
         val projectManager = m.mock(ProjectManager::class.java)
         val repositoryManager = m.mock(RepositoryManager::class.java)
-        val rootUrlHolder = m.mock(RootUrlHolder::class.java)
+        val rootUrlResolver = m.mock(ProjectAwareRootUrlResolver::class.java)
         val buildStartContext = m.mock(BuildStartContext::class.java)
         val build = m.mock(SRunningBuild::class.java)
         val project = m.mock(SProject::class.java)
@@ -36,7 +36,7 @@ class NuGetFeedAuthParametersProviderTest {
         val projectId = "projectId"
 
         val parametersProvider = NuGetFeedAuthParametersProvider(
-                serverSettings, projectManager, repositoryManager, rootUrlHolder
+                serverSettings, projectManager, repositoryManager, rootUrlResolver
         )
 
         m.checking(object: Expectations() {
@@ -71,7 +71,7 @@ class NuGetFeedAuthParametersProviderTest {
                     }
                 })
 
-                oneOf(rootUrlHolder).rootUrl
+                oneOf(rootUrlResolver).getRootUrlByProjectInternalId(projectId)
                 will(returnValue("http://localhost"))
 
                 oneOf(buildStartContext).addSharedParameter("teamcity.nuget.feed.agentSideIndexing", "true")

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedRootUrlResolverTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/feed/NuGetFeedRootUrlResolverTest.kt
@@ -1,0 +1,102 @@
+package jetbrains.buildServer.nuget.tests.feed
+
+import jetbrains.buildServer.BaseTestCase
+import jetbrains.buildServer.ProjectAwareRootUrlResolver
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver
+import jetbrains.buildServer.nuget.tests.integration.feed.server.RequestWrapper
+import jetbrains.buildServer.nuget.tests.util.TCJMockUtils
+import jetbrains.buildServer.web.util.PathModifiers
+import jetbrains.buildServer.web.util.WebUtil
+import org.assertj.core.api.Assertions
+import org.jmock.Expectations
+import org.jmock.Mockery
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+import javax.servlet.http.HttpServletRequest
+
+class NuGetFeedRootUrlResolverTest : BaseTestCase() {
+
+    private lateinit var myMockery: Mockery
+    private lateinit var myProjectAwareResolver: ProjectAwareRootUrlResolver
+    private lateinit var myResolver: NuGetFeedRootUrlResolver
+
+    @BeforeMethod
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        myMockery = TCJMockUtils.createInstance()
+        myProjectAwareResolver = myMockery.mock(ProjectAwareRootUrlResolver::class.java)
+        myResolver = NuGetFeedRootUrlResolver(myProjectAwareResolver)
+        registerHttpAuthPathModifier()
+    }
+
+    @Test
+    fun testRequestUrlIsUsedWhenProjectDoesNotRedefineRootUrl() {
+        expectProjectRootUrl(PROJECT_EXT_ID, GLOBAL_URL)
+
+        Assertions.assertThat(myResolver.getRootUrl(createRequest(), PROJECT_EXT_ID)).isEqualTo(REQUEST_URL)
+        Assertions.assertThat(myResolver.getRootUrlWithAuthenticationType(createRequest(), PROJECT_EXT_ID))
+            .isEqualTo("$REQUEST_URL/httpAuth")
+    }
+
+    @Test
+    fun testProjectUrlOverridesRequestUrl() {
+        expectProjectRootUrl(PROJECT_EXT_ID, PROJECT_URL)
+
+        Assertions.assertThat(myResolver.getRootUrl(createRequest(), PROJECT_EXT_ID)).isEqualTo(PROJECT_URL)
+        Assertions.assertThat(myResolver.getRootUrlWithAuthenticationType(createRequest(), PROJECT_EXT_ID))
+            .isEqualTo("$PROJECT_URL/httpAuth")
+    }
+
+    @Test
+    fun testTrailingSlashOfProjectUrlIsRemoved() {
+        expectProjectRootUrl(PROJECT_EXT_ID, "$PROJECT_URL/")
+
+        Assertions.assertThat(myResolver.getRootUrl(createRequest(), PROJECT_EXT_ID)).isEqualTo(PROJECT_URL)
+        Assertions.assertThat(myResolver.getRootUrlWithAuthenticationType(createRequest(), PROJECT_EXT_ID))
+            .isEqualTo("$PROJECT_URL/httpAuth")
+    }
+
+    @Test
+    fun testUnknownProjectFallsBackToRequestUrl() {
+        expectProjectRootUrl(null, GLOBAL_URL)
+
+        Assertions.assertThat(myResolver.getRootUrl(createRequest(), null)).isEqualTo(REQUEST_URL)
+        Assertions.assertThat(myResolver.getRootUrlWithAuthenticationType(createRequest(), null))
+            .isEqualTo("$REQUEST_URL/httpAuth")
+    }
+
+    private fun expectProjectRootUrl(projectExtId: String?, projectRootUrl: String) {
+        myMockery.checking(object : Expectations() {
+            init {
+                allowing(myProjectAwareResolver).rootUrl
+                will(returnValue(GLOBAL_URL))
+                allowing(myProjectAwareResolver).getRootUrlByProjectExternalId(projectExtId)
+                will(returnValue(projectRootUrl))
+            }
+        })
+    }
+
+    private fun createRequest(): HttpServletRequest {
+        val request = RequestWrapper(SERVLET_PATH, "$SERVLET_PATH/index.json")
+        request.setServerPort(8111)
+        return request
+    }
+
+    private fun registerHttpAuthPathModifier() {
+        val pathModifiers = PathModifiers()
+        pathModifiers.init()
+        pathModifiers.registerPathModifier(object : PathModifiers.PathModifier {
+            override fun matches(path: String) = path.startsWith(WebUtil.HTTP_AUTH_PREFIX)
+            override fun modifyPath(path: String) = path.substring(WebUtil.HTTP_AUTH_PREFIX.length - 1)
+        })
+    }
+
+    companion object {
+        private const val PROJECT_EXT_ID = "Project1"
+        private const val GLOBAL_URL = "http://teamcity.example.com"
+        private const val PROJECT_URL = "https://tenant.example.com"
+        private const val REQUEST_URL = "http://localhost:8111"
+        private const val SERVLET_PATH = "/httpAuth/app/nuget/feed/Project1/default/v3"
+    }
+}

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/json/JsonRegistrationTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/json/JsonRegistrationTest.kt
@@ -31,6 +31,18 @@ class JsonRegistrationTest : JsonFeedIntegrationTestBase() {
     }
 
     @Test
+    fun get_package_registrations_with_project_root_url() {
+        myProjectRootUrl = PROJECT_ROOT_URL
+        addMockPackage("MyPackage", "1.0.0.0")
+
+        val responseBody = openRequest("registration1/mypackage/index.json")
+
+        assertContains(responseBody, "{\"@id\":\"$PROJECT_ROOT_URL$myAuthenticationType$SERVLET_V3_PATH")
+        assertContains(responseBody, "\"packageContent\":\"$PROJECT_ROOT_URL$myAuthenticationType$DOWNLOAD_URL")
+        assertNotContains(responseBody, serverUrl, false)
+    }
+
+    @Test
     fun get_not_existing_package_registrations() {
         assertStatusCode(HttpStatus.SC_NOT_FOUND, "registration1/mypackage/index.json")
     }
@@ -105,5 +117,9 @@ class JsonRegistrationTest : JsonFeedIntegrationTestBase() {
                 .dependencies.first()
         Assert.assertEquals(dependency.id, id)
         Assert.assertEquals(dependency.range, range)
+    }
+
+    companion object {
+        private const val PROJECT_ROOT_URL = "https://tenant.example.com"
     }
 }

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetFeedUploadMetadataStdHandlerTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetFeedUploadMetadataStdHandlerTest.kt
@@ -50,9 +50,9 @@ class NuGetFeedUploadMetadataStdHandlerTest {
         m.checking(object: Expectations() {
             init {
                 allowing(myContext).feedData;
-                will(returnValue(NuGetFeedData(PROJECT_ID, FEED_ID)))
+                will(returnValue(NuGetFeedData(PROJECT_ID, PROJECT_ID, FEED_ID)))
 
-                allowing(myPermissionChecker).canWrite(myBuild, NuGetFeedData(PROJECT_ID, FEED_ID))
+                allowing(myPermissionChecker).canWrite(myBuild, NuGetFeedData(PROJECT_ID, PROJECT_ID, FEED_ID))
                 will(returnValue(true))
             }
         })

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetJavaFeedIntegrationTestBase.java
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetJavaFeedIntegrationTestBase.java
@@ -4,6 +4,7 @@ package jetbrains.buildServer.nuget.tests.integration.feed.server;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.intellij.util.containers.SortedList;
+import jetbrains.buildServer.ProjectAwareRootUrlResolver;
 import jetbrains.buildServer.controllers.MockResponse;
 import jetbrains.buildServer.nuget.common.index.PackageAnalyzer;
 import jetbrains.buildServer.nuget.common.index.PackageConstants;
@@ -19,6 +20,7 @@ import jetbrains.buildServer.nuget.feed.server.controllers.upload.NuGetFeedStdUp
 import jetbrains.buildServer.nuget.feed.server.controllers.upload.NuGetFeedUploadHandlerStdContext;
 import jetbrains.buildServer.nuget.feed.server.controllers.upload.NuGetFeedUploadMetadataHandler;
 import jetbrains.buildServer.nuget.feed.server.controllers.upload.PackageUploadHandler;
+import jetbrains.buildServer.nuget.feed.server.impl.NuGetFeedRootUrlResolver;
 import jetbrains.buildServer.nuget.feed.server.index.*;
 import jetbrains.buildServer.nuget.feed.server.index.impl.PackagesIndexImpl;
 import jetbrains.buildServer.nuget.feed.server.index.impl.SemanticVersionsComparators;
@@ -70,6 +72,7 @@ public class NuGetJavaFeedIntegrationTestBase extends NuGetFeedIntegrationTestBa
   protected static final String SERVLET_PATH = "/app/nuget/feed/_Root/default/v2";
   protected static final String SERVLET_V3_PATH = "/app/nuget/feed/_Root/default/v3";
   protected static final String DOWNLOAD_URL = "/downlaodREpoCon/downlaod-url";
+  protected static final String GLOBAL_ROOT_URL = "http://localhost:8111";
   protected PackagesIndex myIndex;
   protected PackagesIndex myActualIndex;
   protected PackagesIndex myIndexProxy;
@@ -83,6 +86,8 @@ public class NuGetJavaFeedIntegrationTestBase extends NuGetFeedIntegrationTestBa
   protected String myAuthenticationType;
   protected NuGetFeedUploadMetadataHandler<NuGetFeedUploadHandlerStdContext> myMetadataHandler;
   private JsonPackageSourceFactory myPackageSourceFactory;
+  /** Value returned by the mocked {@code getRootUrlByProjectExternalId}; equal to the global URL means "no override". */
+  protected String myProjectRootUrl;
   private JsonPackageAdapterFactory myAdapterFactory;
 
   @Parameters({ "contextPath", "authenticationType", "async" })
@@ -117,6 +122,9 @@ public class NuGetJavaFeedIntegrationTestBase extends NuGetFeedIntegrationTestBa
     final PackageAnalyzer packageAnalyzer = mockery.mock(PackageAnalyzer.class);
     final ResponseCacheReset cacheReset = mockery.mock(ResponseCacheReset.class);
     final ServerSettings serverSettings = mockery.mock(ServerSettings.class);
+    final ProjectAwareRootUrlResolver projectAwareRootUrlResolver = m.mock(ProjectAwareRootUrlResolver.class);
+    final NuGetFeedRootUrlResolver rootUrlResolver = new NuGetFeedRootUrlResolver(projectAwareRootUrlResolver);
+    myProjectRootUrl = GLOBAL_ROOT_URL;
 
     m.checking(new Expectations() {{
       allowing(myIndexProxy).getAll();
@@ -164,6 +172,15 @@ public class NuGetJavaFeedIntegrationTestBase extends NuGetFeedIntegrationTestBa
       allowing(serverSettings).getRootUrl();
       will(returnValue("http://localhost:8111"));
 
+      allowing(projectAwareRootUrlResolver).getRootUrl();
+      will(returnValue(GLOBAL_ROOT_URL));
+      allowing(projectAwareRootUrlResolver).getRootUrlByProjectExternalId(with(any(String.class)));
+      will(new CustomAction("return the project root URL") {
+        public Object invoke(Invocation invocation) {
+          return myProjectRootUrl;
+        }
+      });
+
       final NuGetFeed feed = new NuGetFeed(myIndexProxy, mySettings);
       allowing(myFeedFactory).createFeed(with(any(NuGetFeedData.class)));
       will(returnValue(feed));
@@ -174,14 +191,14 @@ public class NuGetJavaFeedIntegrationTestBase extends NuGetFeedIntegrationTestBa
     }});
 
     final ODataRequestHandler oDataRequestHandler = new ODataRequestHandler(myFeedFactory, responseCache);
-    final OlingoRequestHandler olingoRequestHandler = new OlingoRequestHandler(myFeedFactory, responseCache);
+    final OlingoRequestHandler olingoRequestHandler = new OlingoRequestHandler(myFeedFactory, responseCache, rootUrlResolver);
     final NuGetFeedStdUploadHandler uploadHandler =
       new NuGetFeedStdUploadHandler(new PackageUploadHandler<NuGetFeedUploadHandlerStdContext>(runningBuilds, packageAnalyzer, cacheReset, myMetadataHandler));
     final JsonRequestHandler jsonRequestHandler = new JsonRequestHandler(
-      new JsonServiceIndexHandler(),
-      new JsonSearchQueryHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory),
-      new JsonRegistrationHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory),
-      new JsonPackageContentHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory),
+      new JsonServiceIndexHandler(rootUrlResolver),
+      new JsonSearchQueryHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory, rootUrlResolver),
+      new JsonRegistrationHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory, rootUrlResolver),
+      new JsonPackageContentHandler(myFeedFactory, myPackageSourceFactory, myAdapterFactory, rootUrlResolver),
       new JsonAutocompleteHandler(myFeedFactory)
     );
     myFeedProvider = new NuGetFeedProviderImpl(oDataRequestHandler, olingoRequestHandler, jsonRequestHandler, uploadHandler);

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetServiceFeedUploadMetadataHandlerTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/integration/feed/server/NuGetServiceFeedUploadMetadataHandlerTest.kt
@@ -30,10 +30,10 @@ class NuGetServiceFeedUploadMetadataHandlerTest {
     fun targetFeedsProvider(): Array<Array<out Any?>> {
         return arrayOf(
                 arrayOf(setOf<NuGetFeedData>()),
-                arrayOf(setOf<NuGetFeedData>(NuGetFeedData("projectId1", "feedId1"))),
+                arrayOf(setOf<NuGetFeedData>(NuGetFeedData("projectId1", "projectId1", "feedId1"))),
                 arrayOf(setOf<NuGetFeedData>(
-                        NuGetFeedData("projectId1", "feedId1"),
-                        NuGetFeedData("projectId2", "feedId2")
+                        NuGetFeedData("projectId1", "projectId1", "feedId1"),
+                        NuGetFeedData("projectId2", "projectId2", "feedId2")
                 ))
         )
     }

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/NamedPackagesUpdateCheckerTest.java
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/NamedPackagesUpdateCheckerTest.java
@@ -4,7 +4,7 @@ package jetbrains.buildServer.nuget.tests.server;
 
 import jetbrains.buildServer.BaseTestCase;
 import jetbrains.buildServer.ExtensionHolder;
-import jetbrains.buildServer.RootUrlHolder;
+import jetbrains.buildServer.ProjectAwareRootUrlResolver;
 import jetbrains.buildServer.agent.AgentRuntimeProperties;
 import jetbrains.buildServer.buildTriggers.BuildTriggerDescriptor;
 import jetbrains.buildServer.buildTriggers.BuildTriggerException;
@@ -68,7 +68,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
   private PackageChangesManager chk;
   private Map<String, String> params;
   private File nugetFakePath;
-  private RootUrlHolder myRootUrlHolder;
+  private ProjectAwareRootUrlResolver myRootUrlResolver;
   private BuildTypeEx myBuildType;
   private ProjectEx myProject;
 
@@ -87,7 +87,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
     params = new TreeMap<String, String>();
     final ServerToolManager toolManager = m.mock(ServerToolManager.class);
     chk = m.mock(PackageChangesManager.class);
-    myRootUrlHolder = m.mock(RootUrlHolder.class);
+    myRootUrlResolver = m.mock(ProjectAwareRootUrlResolver.class);
     myBuildType = m.mock(BuildTypeEx.class);
     myProject = m.mock(ProjectEx.class);
 
@@ -108,7 +108,7 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
       allowing(context).getBuildType(); will(returnValue(myBuildType));
       allowing(desr).getProperties(); will(returnValue(params));
       allowing(toolManager).getUnpackedToolVersionPath(with(any(ToolType.class)), with(any(String.class)), with(any(SProject.class))); will(returnValue(nugetHome));
-      allowing(extensionHolder).getExtensions(TriggerUrlPostProcessor.class); will(returnValue(Collections.<TriggerUrlPostProcessor>singletonList(new TriggerUrlRootPostProcessor(myRootUrlHolder))));
+      allowing(extensionHolder).getExtensions(TriggerUrlPostProcessor.class); will(returnValue(Collections.<TriggerUrlPostProcessor>singletonList(new TriggerUrlRootPostProcessor(myRootUrlResolver))));
       allowing(myBuildType).getProject(); will(returnValue(myProject));
 
       allowing(si).canStartNuGetProcesses(); will(new CustomAction("Return myIsWindows") {
@@ -129,7 +129,8 @@ public class NamedPackagesUpdateCheckerTest extends BaseTestCase {
     params.put(TriggerConstants.SOURCE, "%"+ AgentRuntimeProperties.TEAMCITY_SERVER_URL+"%/a/b/c");
 
     m.checking(new Expectations(){{
-      allowing(myRootUrlHolder).getRootUrl(); will(returnValue("http://some-teamcity-with-nuget.org/jonnyzzz"));
+      allowing(myProject).getExternalId(); will(returnValue("MyProject"));
+      allowing(myRootUrlResolver).getRootUrlByProjectExternalId("MyProject"); will(returnValue("http://some-teamcity-with-nuget.org/jonnyzzz"));
 
       oneOf(chk).checkPackage(with(req(nugetFakePath, "http://some-teamcity-with-nuget.org/jonnyzzz/a/b/c", "NUnit", null)));
       will(returnValue(CheckResult.fromResult(Arrays.asList(new SourcePackageInfo("src", "pkg", "5.6.87")))));

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetArtifactsMetadataProviderTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetArtifactsMetadataProviderTest.kt
@@ -224,7 +224,7 @@ class NuGetArtifactsMetadataProviderTest {
                 will(returnValue(true))
 
                 oneOf(targetFeedProvider).getFeeds(build)
-                will(returnValue(setOf(NuGetFeedData("projectId", "feed"))))
+                will(returnValue(setOf(NuGetFeedData("projectId", "projectId", "feed"))))
 
                 oneOf(projectManager).findProjectById("projectId")
                 will(returnValue(project))

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetBuildFeedsProviderTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetBuildFeedsProviderTest.kt
@@ -74,13 +74,13 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
                 allowing(repositoryManager).getRepositories(buildProject, true); will(indexedRepos())
                 stubFeature(OWN_FEED)
                 allowing(projectManager).findProjectByExternalId(BUILD_PROJECT); will(returnValue(buildProject))
-                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, FEED_NAME))
+                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, FEED_NAME))
             }
         })
 
         val result = provider.resolveIndexerFeeds(build)
 
-        Assert.assertTrue(result.accessible.contains(NuGetFeedData(BUILD_PROJECT, FEED_NAME)))
+        Assert.assertTrue(result.accessible.contains(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, FEED_NAME)))
         Assert.assertTrue(result.rejected.isEmpty())
     }
 
@@ -90,7 +90,7 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
                 stubBuildProject()
                 allowing(repositoryManager).getRepositories(buildProject, true); will(indexedRepos())
                 stubFeature(FOREIGN_FEED)
-                allowing(foreignProject).projectId; will(returnValue(FOREIGN_PROJECT))
+                stubForeignProject()
                 allowing(projectManager).findProjectByExternalId(FOREIGN_PROJECT); will(returnValue(foreignProject))
                 stubWritableFeeds()
             }
@@ -109,7 +109,7 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
                 stubBuildProject()
                 allowing(repositoryManager).getRepositories(buildProject, true); will(indexedRepos())
                 stubFeature(FOREIGN_FEED)
-                allowing(foreignProject).projectId; will(returnValue(FOREIGN_PROJECT))
+                stubForeignProject()
                 allowing(projectManager).findProjectByExternalId(FOREIGN_PROJECT); will(returnValue(foreignProject))
                 allowing(repositoryManager).hasRepository(foreignProject, PackageConstants.NUGET_PROVIDER_ID, FEED_NAME)
                 will(returnValue(true))
@@ -119,7 +119,7 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
 
         val result = provider.resolveIndexerFeeds(build)
 
-        Assert.assertTrue(result.accessible.contains(NuGetFeedData(FOREIGN_PROJECT, FEED_NAME)))
+        Assert.assertTrue(result.accessible.contains(NuGetFeedData(FOREIGN_PROJECT, FOREIGN_PROJECT, FEED_NAME)))
         Assert.assertTrue(result.rejected.isEmpty())
     }
 
@@ -161,11 +161,11 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
                 stubBuildProject()
                 allowing(repositoryManager).getRepositories(buildProject, true); will(indexedRepos("impl"))
                 allowing(build).getBuildFeaturesOfType(NuGetFeedConstants.NUGET_INDEXER_TYPE); will(returnValue(emptyList<SBuildFeatureDescriptor>()))
-                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, "impl"))
+                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, "impl"))
             }
         })
 
-        Assert.assertTrue(provider.resolveIndexerFeeds(build).accessible.contains(NuGetFeedData(BUILD_PROJECT, "impl")))
+        Assert.assertTrue(provider.resolveIndexerFeeds(build).accessible.contains(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, "impl")))
     }
 
     fun getFeedsReturnsAccessibleFeeds() {
@@ -175,17 +175,23 @@ class NuGetBuildFeedsProviderTest : BaseTestCase() {
                 allowing(repositoryManager).getRepositories(buildProject, true); will(indexedRepos())
                 stubFeature(OWN_FEED)
                 allowing(projectManager).findProjectByExternalId(BUILD_PROJECT); will(returnValue(buildProject))
-                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, FEED_NAME))
+                stubWritableFeeds(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, FEED_NAME))
             }
         })
 
-        Assert.assertTrue(provider.getFeeds(build).contains(NuGetFeedData(BUILD_PROJECT, FEED_NAME)))
+        Assert.assertTrue(provider.getFeeds(build).contains(NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, FEED_NAME)))
     }
 
     private fun Expectations.stubBuildProject() {
         allowing(build).projectId; will(AbstractExpectations.returnValue(BUILD_PROJECT))
         allowing(buildProject).projectId; will(AbstractExpectations.returnValue(BUILD_PROJECT))
+        allowing(buildProject).externalId; will(AbstractExpectations.returnValue(BUILD_PROJECT))
         allowing(projectManager).findProjectById(BUILD_PROJECT); will(AbstractExpectations.returnValue(buildProject))
+    }
+
+    private fun Expectations.stubForeignProject() {
+        allowing(foreignProject).projectId; will(AbstractExpectations.returnValue(FOREIGN_PROJECT))
+        allowing(foreignProject).externalId; will(AbstractExpectations.returnValue(FOREIGN_PROJECT))
     }
 
     private fun Expectations.stubWritableFeeds(vararg feeds: NuGetFeedData) {

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetIndexerFeedAccessReporterTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/NuGetIndexerFeedAccessReporterTest.kt
@@ -61,7 +61,7 @@ class NuGetIndexerFeedAccessReporterTest {
         m.checking(object : Expectations() {
             init {
                 allowing(feedsProvider).resolveIndexerFeeds(build)
-                will(returnValue(IndexerFeedsResolutionResult(setOf(NuGetFeedData("Child", "packages")), emptyList())))
+                will(returnValue(IndexerFeedsResolutionResult(setOf(NuGetFeedData("Child", "Child", "packages")), emptyList())))
                 never(build).addBuildProblem(with(any(BuildProblemData::class.java)))
             }
         })

--- a/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/security/NuGetFeedPermissionCheckerTest.kt
+++ b/nuget-tests/src/jetbrains/buildServer/nuget/tests/server/feed/server/security/NuGetFeedPermissionCheckerTest.kt
@@ -55,17 +55,17 @@ class NuGetFeedPermissionCheckerTest {
 
     fun canWriteAllowsOwnFeed() {
         m.checking(object : Expectations() { init { stubBuildProjectWithVisibleFeeds(buildProject to FEED_NAME) } })
-        Assert.assertTrue(checker.canWrite(build, NuGetFeedData(BUILD_PROJECT, FEED_NAME)))
+        Assert.assertTrue(checker.canWrite(build, NuGetFeedData(BUILD_PROJECT, BUILD_PROJECT, FEED_NAME)))
     }
 
     fun canWriteDeniesUnrelatedFeed() {
         m.checking(object : Expectations() { init { stubBuildProjectWithVisibleFeeds(buildProject to FEED_NAME) } })
-        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(FOREIGN_PROJECT, FEED_NAME)))
+        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(FOREIGN_PROJECT, FOREIGN_PROJECT, FEED_NAME)))
     }
 
     fun canWriteDeniesDescendantFeed() {
         m.checking(object : Expectations() { init { stubBuildProjectWithVisibleFeeds(buildProject to FEED_NAME) } })
-        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(DESCENDANT_PROJECT, FEED_NAME)))
+        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(DESCENDANT_PROJECT, DESCENDANT_PROJECT, FEED_NAME)))
     }
 
     fun canWriteDeniesWhenBuildProjectMissing() {
@@ -75,7 +75,7 @@ class NuGetFeedPermissionCheckerTest {
                 allowing(projectManager).findProjectById(BUILD_PROJECT); will(returnValue(null))
             }
         })
-        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(PARENT_PROJECT, FEED_NAME)))
+        Assert.assertFalse(checker.canWrite(build, NuGetFeedData(PARENT_PROJECT, PARENT_PROJECT, FEED_NAME)))
     }
 
     private fun Expectations.stubBuildProjectWithVisibleFeeds(vararg specs: Pair<SProject, String>) {

--- a/nuget-tests/src/testng-nuget-fast.xml
+++ b/nuget-tests/src/testng-nuget-fast.xml
@@ -92,6 +92,7 @@
       <class name="jetbrains.buildServer.nuget.tests.feed.NuGetUtilsTest"/>
       <class name="jetbrains.buildServer.nuget.tests.feed.NuGetCsrfCheckTest"/>
       <class name="jetbrains.buildServer.nuget.tests.feed.NuGetFeedAuthParametersProviderTest"/>
+      <class name="jetbrains.buildServer.nuget.tests.feed.NuGetFeedRootUrlResolverTest"/>
       <class name="jetbrains.buildServer.nuget.tests.feed.NuGetFeedParametersProviderTest"/>
       <class name="jetbrains.buildServer.nuget.tests.server.SystemInfoTest"/>
       <class name="jetbrains.buildServer.nuget.tests.server.VersionConstraintTest"/>


### PR DESCRIPTION
The pull request ensured NuGet Feed uses project-scoped URLs whenever configured. 